### PR TITLE
Add paper summary section to audio sample page

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,19 @@
           <li><strong>STOIi</strong>: short‑time objective intelligibility improvement</li>
         </ul>
       </section>
+
+      <section class="overview">
+        <h3>Paper summary</h3>
+        <p>
+          The paper presents a semi-blind source separation framework for
+          unmanned aerial vehicle audition based on supervised independent
+          low-rank matrix analysis. Variants incorporating recursive covariance
+          estimation (RCSCME) and weighted filtering (WF) achieve notable
+          improvements in SDRi and STOIi at both 3&nbsp;m and 5&nbsp;m measurement
+          distances. Refer to the publication for full methodological and
+          experimental details.
+        </p>
+      </section>
     </header>
 
     <!-- Sections are injected by JS below to avoid repeating markup.  -->


### PR DESCRIPTION
## Summary
- Add a short summary of the Semi-Blind Source Separation for UAV audition paper to the project webpage.

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a39a12f0832db2be51e09ad2cedf