### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 This repository contains audio samples accompanying our paper titled "Semi-Blind Source Separation for Unmanned Aerial Vehicle audition".
 
 You can play the audio samples online [here](https://jinxuanteh.github.io/audio-sample-supervised-ILRMA-UAV/)
+
+The demo webpage now includes a light/dark mode toggle for easier viewing.

--- a/index.html
+++ b/index.html
@@ -11,10 +11,16 @@
       --bg:#f7f7fb; --fg:#1f2937; --muted:#6b7280; --card:#ffffff;
       --brand:#0b63f6; --rule:#e5e7eb; --chip:#eef2ff; --chipfg:#1e3a8a;
     }
+    body.dark{
+      --bg:#1f2937; --fg:#f7f7fb; --muted:#9ca3af; --card:#374151;
+      --rule:#4b5563; --chip:#1f2937; --chipfg:#bfdbfe;
+    }
     *{box-sizing:border-box}
     html,body{height:100%}
     body{margin:0;font-family:"Segoe UI", SegoeUI, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;color:var(--fg);background:var(--bg);line-height:1.6}
     .wrap{max-width:980px;margin:48px auto;padding:32px;background:var(--card);border-radius:14px;box-shadow:0 12px 32px rgba(0,0,0,.06)}
+    header{position:relative}
+    #theme-toggle{position:absolute;top:0;right:0;background:none;border:none;font-size:1.4rem;cursor:pointer;color:var(--fg)}
     h1{font-size:2.8em;margin-bottom:.75rem;color:#212529;font-weight:600}
     h2{font-size:1.3em;margin:0 0 .5rem;font-weight:400;color:#6c757d}
     .subtitle-title{font-size:1.8em;color:#111;font-weight:600;margin:0 0 .5rem}
@@ -69,6 +75,7 @@
 <body>
   <main class="wrap" id="app">
     <header>
+      <button id="theme-toggle" aria-label="Toggle dark mode"></button>
       <h1>Audio samples</h1>
       <h2 class="subtitle-title">Semi‑Blind Source Separation for Unmanned Aerial Vehicle audition</h2>
       <div class="authors">
@@ -105,6 +112,20 @@
   </main>
 
   <script>
+    // —— THEME TOGGLE ——
+    const themeToggle = document.getElementById('theme-toggle');
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (prefersDark) {
+      document.body.classList.add('dark');
+      themeToggle.textContent = '☀️';
+    } else {
+      themeToggle.textContent = '🌙';
+    }
+    themeToggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark');
+      themeToggle.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
+    });
+
     // —— CONFIGURATION ——
     // Folder holding audio. Kept as path segments to safely URL‑encode spaces.
     const ROOT = ["audio samples"]; // must exist next to this HTML file


### PR DESCRIPTION
## Summary
- add dark mode color variables and theme toggle button
- enable theme selection respecting system preference and user toggle
- document dark mode in README

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a5956fe0832d9e2e0bffa46dac2e